### PR TITLE
Added flexible space matching for Section markers

### DIFF
--- a/syntaxes/psl.tmLanguage.json
+++ b/syntaxes/psl.tmLanguage.json
@@ -277,8 +277,8 @@
 			"patterns": [
 				{
 					"name": "comment.block.psl",
-					"begin": "^---------- REVHIST ------ Section marker",
-					"end": "^---------- OPEN ------ Section marker",
+					"begin": "^---------- REVHIST\\s+------ Section marker",
+					"end": "^---------- OPEN\\s+------ Section marker",
 					"beginCaptures": {
 						"0": {
 							"patterns": [


### PR DESCRIPTION
Our batch definitions have 4 spaces after the OPEN section marker, which fails the current pattern, so the whole file ends up looking like a comment. This fixes that problem.